### PR TITLE
Fix a github AMA link

### DIFF
--- a/site/content/templates/index/index.html
+++ b/site/content/templates/index/index.html
@@ -32,7 +32,7 @@
     </header>
 
     <section class="ama">
-      <p>Got a burning question for me? check out my <a href="http://github.com">github AMA</a>.</p>
+      <p>Got a burning question for me? check out my <a href="https://github.com/rachsmithcodes/ama">github AMA</a>.</p>
 
     </section>
     <main>


### PR DESCRIPTION
All your other github ama links point to the actual repo. I assumed this one should too